### PR TITLE
enable prefix caching

### DIFF
--- a/reward_hub/vllm/reward.py
+++ b/reward_hub/vllm/reward.py
@@ -23,6 +23,7 @@ class VllmProcessRewardModel(AbstractProcessRewardModel):
                     task="reward",
                     device=device,
                     gpu_memory_utilization=0.8,
+                    enable_prefix_caching=True,
                     tensor_parallel_size=1,
                     )
         self.tokenizer = AutoTokenizer.from_pretrained(model_name)


### PR DESCRIPTION
to make reward computations faster when using vllm