### PR TITLE
Update python build action for 3.14 compatibility

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -49,7 +49,7 @@ jobs:
                   fetch-depth: 0
 
             - name: "Build and Inspect"
-              uses: hynek/build-and-inspect-python-package@b5076c307dc91924a82ad150cdd1533b444d3310 # v2.12.0
+              uses: hynek/build-and-inspect-python-package@efb823f52190ad02594531168b7a2d5790e66516 # v2.14.0
 
     # push to Test PyPI on
     # - a new GitHub release is published


### PR DESCRIPTION
Fixes currently broken python build and inspect action with new GH Actions version