### PR TITLE
vLLM and Transformers Compatibility for PRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 **RewardHub** is an end-to-end library for annotating data using state-of-the-art (SoTA) reward models, critic functions, and related processes. It is designed to facilitate the generation of preference training data or define acceptance criteria for agentic or inference scaling systems such as Best-of-N sampling or Beam-Search.
 
-
 ## Getting Started
 
 ### Installation
 
 #### Basic Installation
+
 For all functionality including HuggingFace, VLLM, and OpenAI backends:
 
 ```bash
@@ -17,15 +17,15 @@ pip install -e .
 ```
 
 #### PRM Installation (Qwen-PRM Support)
+
 If you need to use Qwen Process Reward Models (e.g., `Qwen/Qwen2.5-Math-PRM-7B`), install with the `prm` extra:
 
 ```bash
 pip install -e .[prm]
 ```
 
-**Note:** This pins `transformers==4.53.2` (instead of the newer `>=4.53.2`) to ensure compatibility with Qwen-PRM models. If you don't need Qwen-PRM support, use the basic installation to get the latest transformers version.
-
 #### Development Installation
+
 For development with additional tools (pytest, ruff, pre-commit):
 
 ```bash
@@ -37,6 +37,7 @@ pip install -e .[dev]
 RewardHub supports multiple types of reward models and serving methods. Here are the main ways to use the library:
 
 #### Process Reward Models (PRM)
+
 PRMs evaluate responses by analyzing the reasoning process:
 
 ```python
@@ -60,6 +61,7 @@ scores = model.score(messages, return_full_prm_result=False)
 ```
 
 #### Outcome Reward Models (ORM)
+
 ORMs focus on evaluating the final response quality:
 
 ```python
@@ -77,6 +79,7 @@ scores = model.score([
 ```
 
 #### DrSow Reward Model
+
 DrSow uses density ratios between strong and weak models to evaluate responses:
 
 Launch the strong and weak models first.
@@ -110,6 +113,7 @@ scores = model.score([
 ```
 
 #### LLM-as-a-Judge
+
 Use LLMs to evaluate conversation quality with customizable criteria:
 
 ```python
@@ -147,17 +151,17 @@ RewardHub supports multiple serving backends:
 
 We support various reward models including:
 
-| Model | Type | HuggingFace | VLLM | OpenAI |
-|-------|------|-------------|------|---------|
-| `Qwen/Qwen2.5-Math-PRM-7B` | PRM | ✓ | ✓ | ✗ |
-| `internlm/internlm2-7b-reward` | ORM | ✓ | ✗ | ✗ |
-| `RLHFlow/Llama3.1-8B-PRM-Deepseek-Data` | PRM | ✓ | ✗ | ✗ |
-| `RLHFlow/ArmoRM-Llama3-8B-v0.1` | ORM | ✗ | ✗ | ✗ |
-| `drsow` | ORM | ✗ | ✗ | ✓ |
+| Model                                   | Type | HuggingFace | VLLM | OpenAI |
+| --------------------------------------- | ---- | ----------- | ---- | ------ |
+| `Qwen/Qwen2.5-Math-PRM-7B`              | PRM  | ✓           | ✓    | ✗      |
+| `internlm/internlm2-7b-reward`          | ORM  | ✓           | ✗    | ✗      |
+| `RLHFlow/Llama3.1-8B-PRM-Deepseek-Data` | PRM  | ✓           | ✗    | ✗      |
+| `RLHFlow/ArmoRM-Llama3-8B-v0.1`         | ORM  | ✗           | ✗    | ✗      |
+| `drsow`                                 | ORM  | ✗           | ✗    | ✓      |
 
 ## Research
 
 **RewardHub** serves as the official implementation of the paper:  
-[**Dr. SoW: Density Ratio of Strong-over-weak LLMs for Reducing the Cost of Human Annotation in Preference Tuning**](https://arxiv.org/pdf/2411.02481)  
+[**Dr. SoW: Density Ratio of Strong-over-weak LLMs for Reducing the Cost of Human Annotation in Preference Tuning**](https://arxiv.org/pdf/2411.02481)
 
 The paper introduces CDR, a novel approach to generating high-quality preference annotations using density ratios tailored to domain-specific needs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ vllm = [
 
 # Optionally extend support for Qwen-PRM
 prm = [
-    "vllm<=0.12.0",
-    "transformers<=4.57.3"
+    "vllm>=0.10.0,<=0.12.0",
+    "transformers>=4.54,<=4.57.3"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "litellm>=1.70.0,<1.75.0",
     "python-dotenv>=1.0.0",
     "tenacity>=8.0.0",
+    "anyio",
 ]
 
 [tool.setuptools_scm]
@@ -57,8 +58,8 @@ vllm = [
 
 # Optionally extend support for Qwen-PRM
 prm = [
-    "vllm<=0.9.1",
-    "transformers==4.53.2"
+    "vllm>=0.12.0",
+    "transformers>=4.57.3"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ vllm = [
 
 # Optionally extend support for Qwen-PRM
 prm = [
-    "vllm>=0.12.0",
-    "transformers>=4.57.3"
+    "vllm<=0.12.0",
+    "transformers<=4.57.3"
 ]
 
 [project.urls]

--- a/reward_hub/hf/reward.py
+++ b/reward_hub/hf/reward.py
@@ -206,7 +206,7 @@ class HuggingFaceProcessRewardModel(AbstractProcessRewardModel):
                 ).to(self.model.device)
                 step_sep_id = self.tokenizer.encode("<extra_0>")[0]
                 token_masks = (all_input_ids == step_sep_id)
-                all_outputs = self.model(input_ids=all_input_ids)
+                all_outputs = self.model(input_ids=all_input_ids, use_cache=False)
                 all_scores.append(make_step_rewards(all_outputs[0], token_masks)[0])
         else:
             raise ValueError(f"Model {self.model_name} is not supported")

--- a/reward_hub/vllm/reward.py
+++ b/reward_hub/vllm/reward.py
@@ -79,7 +79,7 @@ class VllmProcessRewardModel(AbstractProcessRewardModel):
                 max_length=max_input_tokens
             ).input_ids
             batch_decoded = self.tokenizer.batch_decode(all_input_ids, skip_special_tokens=False)
-            all_outputs = self.model.encode(batch_decoded, use_tqdm=use_tqdm)
+            all_outputs = self.model.encode(batch_decoded, use_tqdm=use_tqdm, pooling_task="token_classify")
             all_scores = [[d[-1].item() for d in ex.outputs.data] for ex in all_outputs]
 
         else:


### PR DESCRIPTION
`reward_hub` should now support `vllm<=0.12.0` and `transformers<=4.57.3`.

* The vLLM-based PRMs have been tested with `Qwen/Qwen2.5-Math-PRM-7B` and `RLHFlow/Llama3.1-8B-PRM-Deepseek-Data`.
* The hf-based ORMs have been tested with `internlm/internlm2-7b-reward`.

Test with `its_hub` integration:

```python

from its_hub.utils import SAL_STEP_BY_STEP_SYSTEM_PROMPT
from its_hub.lms import OpenAICompatibleLanguageModel, StepGeneration
from its_hub.algorithms import ParticleFiltering, BestOfN, SelfConsistency, EntropicParticleFiltering
from its_hub.integration.reward_hub import LocalVllmProcessRewardModel
from its_hub.integration.reward_hub import LLMJudgeRewardModel

lm = OpenAICompatibleLanguageModel(
    endpoint="http://localhost:8100/v1",
    api_key="NO_API_KEY",
    model_name="Qwen/Qwen2.5-1.5B-Instruct",
    system_prompt=SAL_STEP_BY_STEP_SYSTEM_PROMPT,
)

sg = StepGeneration(step_token="\n\n", max_steps=32, stop_token=r"\boxed")

prm = LocalVllmProcessRewardModel(
    model_name="Qwen/Qwen2.5-Math-PRM-7B",
    device="cuda:0",
    aggregation_method="prod"
)

scaling_alg = ParticleFiltering(sg, prm)

result = scaling_alg.infer(lm, "Explain quantum entanglement in simple terms", budget=4)
```

