### PR TITLE
feat: add structured output mode for LLM judges

### DIFF
--- a/reward_hub/llm_judge/groupwise.py
+++ b/reward_hub/llm_judge/groupwise.py
@@ -1,10 +1,21 @@
-"""Groupwise judge implementation using LiteLLM"""
+"""Groupwise judge implementation using LiteLLM."""
+
+from typing import List, Optional, Union
 
 import litellm
-from typing import List, Optional, Union
+
 from ..base import AbstractOutcomeRewardModel, JudgeResult
 from .prompts import CriterionRegistry, GROUPWISE_PROCEDURAL
-from .utils import validate_api_configuration, parse_json_response, extract_message_content, with_retry
+from .utils import (
+    build_groupwise_response_format,
+    extract_message_content,
+    is_response_format_unsupported_error,
+    normalize_structured_output_mode,
+    parse_json_response,
+    validate_api_configuration,
+    validate_groupwise_judge_result,
+    with_retry,
+)
 
 
 class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
@@ -12,18 +23,21 @@ class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
     Groupwise judge that ranks multiple conversations and returns binary scores.
     Uses LiteLLM for model calls with built-in retry and provider support.
     """
-    
-    def __init__(self, 
-                 model: str,
-                 criterion: str,
-                 api_key: Optional[str] = None,
-                 base_url: Optional[str] = None,
-                 temperature: float = 0.0,
-                 max_tokens: int = 1024,
-                 **litellm_kwargs):
+
+    def __init__(
+        self,
+        model: str,
+        criterion: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        temperature: float = 0.0,
+        max_tokens: int = 1024,
+        structured_output_mode: str = "auto",
+        **litellm_kwargs,
+    ):
         """
         Initialize groupwise judge
-        
+
         Args:
             model: LiteLLM model name (e.g., "gpt-4", "claude-3-sonnet", etc.)
             criterion: Name of registered criterion to use for evaluation
@@ -39,34 +53,65 @@ class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
         self.base_url = base_url
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.structured_output_mode = normalize_structured_output_mode(structured_output_mode)
         self.litellm_kwargs = litellm_kwargs
-        
+
         # Store criterion text for runtime composition
         self.criterion_text = CriterionRegistry.get(criterion)
-        
+
         # Set up LiteLLM configuration
         if api_key:
             litellm.api_key = api_key
         if base_url:
             litellm.api_base = base_url
-        
+
         # Validate API key works by making a test call
         validate_api_configuration(self.model, **self.litellm_kwargs)
-    
+
+    def _completion_request(
+        self,
+        *,
+        judge_messages: List[dict],
+        num_responses: int,
+        top_n: int,
+        use_response_format: bool,
+        **kwargs,
+    ) -> dict:
+        request_kwargs = {
+            "model": self.model,
+            "messages": judge_messages,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            **self.litellm_kwargs,
+            **kwargs,
+        }
+        if use_response_format:
+            request_kwargs["response_format"] = build_groupwise_response_format(
+                num_responses=num_responses,
+                top_n=top_n,
+            )
+        return request_kwargs
+
     def _validate_shared_context(self, conversations: List[List[dict]]) -> None:
         """Validate all conversations share the same context (all messages except last)"""
         first_context = [extract_message_content(msg) for msg in conversations[0][:-1]]
         for i, conv in enumerate(conversations[1:], 1):
             if [extract_message_content(msg) for msg in conv[:-1]] != first_context:
                 raise ValueError(f"Conversation {i} has different context than conversation 0")
-    
-    def score(self, messages: Union[List[List[dict]], List[dict]], top_n: int = 1, return_judge_reasoning: bool = False, **kwargs) -> Union[List[float], JudgeResult]:
+
+    def score(
+        self,
+        messages: Union[List[List[dict]], List[dict]],
+        top_n: int = 1,
+        return_judge_reasoning: bool = False,
+        **kwargs,
+    ) -> Union[List[float], JudgeResult]:
         """
         Score conversations using the OpenAI chat completion format
 
         Args:
             messages: Must be multiple conversations (List[List[dict]]) for groupwise ranking
-            top_n: Number of top conversations to select. Default to top_n = 1, only choose best 1 out of the group. 
+            top_n: Number of top conversations to select. Default to top_n = 1, only choose best 1 out of the group.
             return_judge_reasoning: If True, return JudgeResult with scores and reasonings. If False, return just scores (default).
             **kwargs: Additional arguments passed to LiteLLM
 
@@ -81,11 +126,13 @@ class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
             raise ValueError("GroupwiseJudgeModel requires multiple conversations, got single conversation")
 
         conversations = messages  # List[List[dict]]
+        if top_n < 1 or top_n > len(conversations):
+            raise ValueError(f"top_n must be between 1 and number of conversations ({len(conversations)})")
         scores, reasoning = self._score_groupwise(conversations, top_n, **kwargs)
         if return_judge_reasoning:
             return JudgeResult(scores=scores, reasonings=[reasoning])
         return scores
-    
+
     @with_retry(max_attempts=3, min_wait=0.1, max_wait=10.0)
     def _score_groupwise(self, conversations: List[List[dict]], top_n: int, **kwargs) -> tuple[List[float], str]:
         """
@@ -104,44 +151,79 @@ class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
 
         # Compose full prompt by inserting criterion and runtime variables into procedural template
         full_prompt = GROUPWISE_PROCEDURAL.format(
-            criterion=self.criterion_text,
-            num_responses=len(conversations),
-            top_n=top_n
+            criterion=self.criterion_text, num_responses=len(conversations), top_n=top_n
         )
 
         # Format conversation context and candidate responses
         context_messages = conversations[0][:-1]
-        context_text = "\n".join([f"{msg['role'].capitalize()}: {extract_message_content(msg)}" for msg in context_messages])
-        responses_text = "\n".join([f"Response {i}: {extract_message_content(conv[-1])}" for i, conv in enumerate(conversations)])
+        context_text = "\n".join(
+            [f"{msg['role'].capitalize()}: {extract_message_content(msg)}" for msg in context_messages]
+        )
+        responses_text = "\n".join(
+            [f"Response {i}: {extract_message_content(conv[-1])}" for i, conv in enumerate(conversations)]
+        )
 
         judge_messages = [
             {"role": "system", "content": full_prompt},
-            {"role": "user", "content": f"Conversation Context:\n{context_text}\n\nCandidate Responses:\n{responses_text}"}
+            {
+                "role": "user",
+                "content": f"Conversation Context:\n{context_text}\n\nCandidate Responses:\n{responses_text}",
+            },
         ]
 
-        response = litellm.completion(
-            model=self.model,
-            messages=judge_messages,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            **self.litellm_kwargs,
-            **kwargs
-        )
+        if self.structured_output_mode != "off":
+            request_kwargs = self._completion_request(
+                judge_messages=judge_messages,
+                num_responses=len(conversations),
+                top_n=top_n,
+                use_response_format=True,
+                **kwargs,
+            )
+            try:
+                response = litellm.completion(**request_kwargs)
+                result = parse_json_response(response.choices[0].message.content)
+                selected_indices, reasoning = validate_groupwise_judge_result(
+                    result,
+                    num_responses=len(conversations),
+                    top_n=top_n,
+                )
+            except Exception as exc:
+                if not (self.structured_output_mode == "auto" and is_response_format_unsupported_error(exc)):
+                    raise
+            else:
+                scores = [0.0] * len(conversations)
+                for idx in selected_indices:
+                    scores[idx] = 1.0
+                return scores, reasoning
 
-        # Parse selected indices from JSON response
-        response_text = response.choices[0].message.content
-        result = parse_json_response(response_text)
-        selected_indices = result["selected_indices"]
-        reasoning = result["reasoning"]
+        fallback_kwargs = self._completion_request(
+            judge_messages=judge_messages,
+            num_responses=len(conversations),
+            top_n=top_n,
+            use_response_format=False,
+            **kwargs,
+        )
+        response = litellm.completion(**fallback_kwargs)
+        result = parse_json_response(response.choices[0].message.content)
+        selected_indices, reasoning = validate_groupwise_judge_result(
+            result,
+            num_responses=len(conversations),
+            top_n=top_n,
+        )
 
         # Convert to binary scores
         scores = [0.0] * len(conversations)
         for idx in selected_indices:
-            if 0 <= idx < len(conversations):
-                scores[idx] = 1.0
+            scores[idx] = 1.0
         return scores, reasoning
-    
-    async def ascore(self, messages: Union[List[List[dict]], List[dict]], top_n: int = 1, return_judge_reasoning: bool = False, **kwargs) -> Union[List[float], JudgeResult]:
+
+    async def ascore(
+        self,
+        messages: Union[List[List[dict]], List[dict]],
+        top_n: int = 1,
+        return_judge_reasoning: bool = False,
+        **kwargs,
+    ) -> Union[List[float], JudgeResult]:
         """
         Async version of score
 
@@ -162,11 +244,13 @@ class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
             raise ValueError("GroupwiseJudgeModel requires multiple conversations, got single conversation")
 
         conversations = messages  # List[List[dict]]
+        if top_n < 1 or top_n > len(conversations):
+            raise ValueError(f"top_n must be between 1 and number of conversations ({len(conversations)})")
         scores, reasoning = await self._ascore_groupwise(conversations, top_n, **kwargs)
         if return_judge_reasoning:
             return JudgeResult(scores=scores, reasonings=[reasoning])
         return scores
-    
+
     @with_retry(max_attempts=3, min_wait=0.1, max_wait=10.0)
     async def _ascore_groupwise(self, conversations: List[List[dict]], top_n: int, **kwargs) -> tuple[List[float], str]:
         """
@@ -185,39 +269,68 @@ class GroupwiseJudgeModel(AbstractOutcomeRewardModel):
 
         # Compose full prompt by inserting criterion and runtime variables into procedural template
         full_prompt = GROUPWISE_PROCEDURAL.format(
-            criterion=self.criterion_text,
-            num_responses=len(conversations),
-            top_n=top_n
+            criterion=self.criterion_text, num_responses=len(conversations), top_n=top_n
         )
 
         # Format conversation context and candidate responses
         context_messages = conversations[0][:-1]
-        context_text = "\n".join([f"{msg['role'].capitalize()}: {extract_message_content(msg)}" for msg in context_messages])
-        responses_text = "\n".join([f"Response {i}: {extract_message_content(conv[-1])}" for i, conv in enumerate(conversations)])
+        context_text = "\n".join(
+            [f"{msg['role'].capitalize()}: {extract_message_content(msg)}" for msg in context_messages]
+        )
+        responses_text = "\n".join(
+            [f"Response {i}: {extract_message_content(conv[-1])}" for i, conv in enumerate(conversations)]
+        )
 
         judge_messages = [
             {"role": "system", "content": full_prompt},
-            {"role": "user", "content": f"Conversation Context:\n{context_text}\n\nCandidate Responses:\n{responses_text}"}
+            {
+                "role": "user",
+                "content": f"Conversation Context:\n{context_text}\n\nCandidate Responses:\n{responses_text}",
+            },
         ]
 
-        response = await litellm.acompletion(
-            model=self.model,
-            messages=judge_messages,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            **self.litellm_kwargs,
-            **kwargs
-        )
+        if self.structured_output_mode != "off":
+            request_kwargs = self._completion_request(
+                judge_messages=judge_messages,
+                num_responses=len(conversations),
+                top_n=top_n,
+                use_response_format=True,
+                **kwargs,
+            )
+            try:
+                response = await litellm.acompletion(**request_kwargs)
+                result = parse_json_response(response.choices[0].message.content)
+                selected_indices, reasoning = validate_groupwise_judge_result(
+                    result,
+                    num_responses=len(conversations),
+                    top_n=top_n,
+                )
+            except Exception as exc:
+                if not (self.structured_output_mode == "auto" and is_response_format_unsupported_error(exc)):
+                    raise
+            else:
+                scores = [0.0] * len(conversations)
+                for idx in selected_indices:
+                    scores[idx] = 1.0
+                return scores, reasoning
 
-        # Parse selected indices from JSON response
-        response_text = response.choices[0].message.content
-        result = parse_json_response(response_text)
-        selected_indices = result["selected_indices"]
-        reasoning = result["reasoning"]
+        fallback_kwargs = self._completion_request(
+            judge_messages=judge_messages,
+            num_responses=len(conversations),
+            top_n=top_n,
+            use_response_format=False,
+            **kwargs,
+        )
+        response = await litellm.acompletion(**fallback_kwargs)
+        result = parse_json_response(response.choices[0].message.content)
+        selected_indices, reasoning = validate_groupwise_judge_result(
+            result,
+            num_responses=len(conversations),
+            top_n=top_n,
+        )
 
         # Convert to binary scores
         scores = [0.0] * len(conversations)
         for idx in selected_indices:
-            if 0 <= idx < len(conversations):
-                scores[idx] = 1.0
+            scores[idx] = 1.0
         return scores, reasoning

--- a/reward_hub/llm_judge/pointwise.py
+++ b/reward_hub/llm_judge/pointwise.py
@@ -1,11 +1,21 @@
-"""Pointwise judge implementation using LiteLLM"""
+"""Pointwise judge implementation using LiteLLM."""
 
-import litellm
 import asyncio
 from typing import List, Optional, Union
+
+import litellm
+
 from ..base import AbstractOutcomeRewardModel, JudgeResult
 from .prompts import CriterionRegistry, POINTWISE_PROCEDURAL
-from .utils import validate_api_configuration, parse_json_response, with_retry
+from .utils import (
+    build_pointwise_response_format,
+    is_response_format_unsupported_error,
+    normalize_structured_output_mode,
+    parse_json_response,
+    validate_api_configuration,
+    validate_pointwise_judge_result,
+    with_retry,
+)
 
 
 class PointwiseJudgeModel(AbstractOutcomeRewardModel):
@@ -13,15 +23,18 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
     Pointwise judge that scores individual conversations on a 0-10 scale.
     Uses LiteLLM for model calls with built-in retry and provider support.
     """
-    
-    def __init__(self,
-                 model: str,
-                 criterion: str,
-                 api_key: Optional[str] = None,
-                 base_url: Optional[str] = None,
-                 temperature: float = 0.0,
-                 max_tokens: int = 512,
-                 **litellm_kwargs):
+
+    def __init__(
+        self,
+        model: str,
+        criterion: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        temperature: float = 0.0,
+        max_tokens: int = 512,
+        structured_output_mode: str = "auto",
+        **litellm_kwargs,
+    ):
         """
         Initialize pointwise judge
 
@@ -40,6 +53,7 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
         self.base_url = base_url
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.structured_output_mode = normalize_structured_output_mode(structured_output_mode)
         self.litellm_kwargs = litellm_kwargs
 
         # Compose full prompt by inserting criterion into procedural template
@@ -54,8 +68,23 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
 
         # Validate API key works by making a test call
         validate_api_configuration(self.model, **self.litellm_kwargs)
-    
-    def score(self, messages: Union[List[List[dict]], List[dict]], return_judge_reasoning: bool = False, **kwargs) -> Union[List[float], float, JudgeResult]:
+
+    def _completion_request(self, *, judge_messages: List[dict], use_response_format: bool, **kwargs) -> dict:
+        request_kwargs = {
+            "model": self.model,
+            "messages": judge_messages,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+            **self.litellm_kwargs,
+            **kwargs,
+        }
+        if use_response_format:
+            request_kwargs["response_format"] = build_pointwise_response_format()
+        return request_kwargs
+
+    def score(
+        self, messages: Union[List[List[dict]], List[dict]], return_judge_reasoning: bool = False, **kwargs
+    ) -> Union[List[float], float, JudgeResult]:
         """
         Score conversations using the OpenAI chat completion format
 
@@ -86,7 +115,7 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
             if return_judge_reasoning:
                 return JudgeResult(scores=scores, reasonings=reasonings)
             return scores
-    
+
     @with_retry(max_attempts=3, min_wait=0.1, max_wait=10.0)
     def _score_single(self, messages: List[dict], **kwargs) -> tuple[float, str]:
         """
@@ -101,24 +130,35 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
         """
         judge_messages = [
             {"role": "system", "content": self.full_prompt},
-            {"role": "user", "content": f"Evaluate this conversation: {messages}"}
+            {"role": "user", "content": f"Evaluate this conversation: {messages}"},
         ]
 
-        response = litellm.completion(
-            model=self.model,
-            messages=judge_messages,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            **self.litellm_kwargs,
-            **kwargs
-        )
+        if self.structured_output_mode != "off":
+            request_kwargs = self._completion_request(
+                judge_messages=judge_messages,
+                use_response_format=True,
+                **kwargs,
+            )
+            try:
+                response = litellm.completion(**request_kwargs)
+                result = parse_json_response(response.choices[0].message.content)
+                return validate_pointwise_judge_result(result)
+            except Exception as exc:
+                if not (self.structured_output_mode == "auto" and is_response_format_unsupported_error(exc)):
+                    raise
 
-        response_text = response.choices[0].message.content
-        # Parse numeric score from JSON response
-        result = parse_json_response(response_text)
-        return float(result["score"]), result["reasoning"]
-    
-    async def ascore(self, messages: Union[List[List[dict]], List[dict]], return_judge_reasoning: bool = False, **kwargs) -> Union[List[float], float, JudgeResult]:
+        fallback_kwargs = self._completion_request(
+            judge_messages=judge_messages,
+            use_response_format=False,
+            **kwargs,
+        )
+        response = litellm.completion(**fallback_kwargs)
+        result = parse_json_response(response.choices[0].message.content)
+        return validate_pointwise_judge_result(result)
+
+    async def ascore(
+        self, messages: Union[List[List[dict]], List[dict]], return_judge_reasoning: bool = False, **kwargs
+    ) -> Union[List[float], float, JudgeResult]:
         """
         Async version of score
 
@@ -149,7 +189,7 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
             if return_judge_reasoning:
                 return JudgeResult(scores=scores, reasonings=reasonings)
             return scores
-    
+
     @with_retry(max_attempts=3, min_wait=0.1, max_wait=10.0)
     async def _ascore_single(self, messages: List[dict], **kwargs) -> tuple[float, str]:
         """
@@ -164,21 +204,28 @@ class PointwiseJudgeModel(AbstractOutcomeRewardModel):
         """
         judge_messages = [
             {"role": "system", "content": self.full_prompt},
-            {"role": "user", "content": f"Evaluate the last assistant message given the context: {messages}"}
+            {"role": "user", "content": f"Evaluate the last assistant message given the context: {messages}"},
         ]
 
-        response = await litellm.acompletion(
-            model=self.model,
-            messages=judge_messages,
-            temperature=self.temperature,
-            max_tokens=self.max_tokens,
-            **self.litellm_kwargs,
-            **kwargs
-        )
+        if self.structured_output_mode != "off":
+            request_kwargs = self._completion_request(
+                judge_messages=judge_messages,
+                use_response_format=True,
+                **kwargs,
+            )
+            try:
+                response = await litellm.acompletion(**request_kwargs)
+                result = parse_json_response(response.choices[0].message.content)
+                return validate_pointwise_judge_result(result)
+            except Exception as exc:
+                if not (self.structured_output_mode == "auto" and is_response_format_unsupported_error(exc)):
+                    raise
 
-        response_text = response.choices[0].message.content
-        # Parse numeric score from JSON response
-        result = parse_json_response(response_text)
-        return float(result["score"]), result["reasoning"]
-    
-    
+        fallback_kwargs = self._completion_request(
+            judge_messages=judge_messages,
+            use_response_format=False,
+            **kwargs,
+        )
+        response = await litellm.acompletion(**fallback_kwargs)
+        result = parse_json_response(response.choices[0].message.content)
+        return validate_pointwise_judge_result(result)

--- a/reward_hub/llm_judge/utils.py
+++ b/reward_hub/llm_judge/utils.py
@@ -1,23 +1,24 @@
 """Utility functions for LLM Judge implementations"""
 
-import litellm
-import json
-import inspect
 import functools
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
-from typing import Callable, TypeVar
+import inspect
+import json
+from typing import Any, Callable, TypeVar
 
-T = TypeVar('T')
+import litellm
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+T = TypeVar("T")
 
 
 def validate_api_configuration(model: str, **litellm_kwargs):
     """
     Validate that the API configuration is working by making a minimal test call
-    
+
     Args:
         model: LiteLLM model name to test
         **litellm_kwargs: Additional arguments passed to LiteLLM
-    
+
     Raises:
         ValueError: If API key is invalid or missing
         ConnectionError: If there are network/endpoint issues
@@ -26,25 +27,21 @@ def validate_api_configuration(model: str, **litellm_kwargs):
         # Make a minimal test call to validate the configuration
         test_messages = [
             {"role": "system", "content": "You are a test assistant."},
-            {"role": "user", "content": "Say 'test' and nothing else."}
+            {"role": "user", "content": "Say 'test' and nothing else."},
         ]
-        
+
         response = litellm.completion(
-            model=model,
-            messages=test_messages,
-            max_tokens=5,
-            temperature=0.0,
-            **litellm_kwargs
+            model=model, messages=test_messages, max_tokens=5, temperature=0.0, **litellm_kwargs
         )
-        
+
         # If we get here, the API configuration is working
         if not response or not response.choices:
             raise ValueError(f"Invalid response from {model} - API configuration may be incorrect")
-            
+
     except Exception as e:
         # Parse different types of authentication/configuration errors
         error_msg = str(e).lower()
-        
+
         if "authentication" in error_msg or "api key" in error_msg or "unauthorized" in error_msg:
             raise ValueError(
                 f"API key authentication failed for model '{model}'. "
@@ -59,9 +56,7 @@ def validate_api_configuration(model: str, **litellm_kwargs):
             ) from e
         elif "rate limit" in error_msg or "quota" in error_msg:
             raise ValueError(
-                f"Rate limit or quota exceeded for model '{model}'. "
-                f"Please check your API usage limits. "
-                f"Error: {str(e)}"
+                f"Rate limit or quota exceeded for model '{model}'. Please check your API usage limits. Error: {str(e)}"
             ) from e
         elif "connection" in error_msg or "network" in error_msg or "timeout" in error_msg:
             raise ConnectionError(
@@ -85,28 +80,139 @@ def parse_json_response(response_text: str) -> dict:
     except json.JSONDecodeError:
         # Try to extract JSON from text
         import re
-        json_match = re.search(r'\{.*\}', response_text, re.DOTALL)
+
+        json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
         if json_match:
             return json.loads(json_match.group())
         raise ValueError(f"No valid JSON found in response: {response_text[:100]}...")
 
 
+def normalize_structured_output_mode(mode: str) -> str:
+    normalized = mode.strip().lower()
+    if normalized not in {"auto", "strict", "off"}:
+        raise ValueError(f"Invalid structured_output_mode '{mode}'. Must be one of: auto, strict, off")
+    return normalized
+
+
+def build_pointwise_response_format() -> dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "pointwise_judge_response",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "reasoning": {"type": "string"},
+                    "score": {"type": "number", "minimum": 0.0, "maximum": 10.0},
+                },
+                "required": ["reasoning", "score"],
+            },
+        },
+    }
+
+
+def build_groupwise_response_format(*, num_responses: int, top_n: int) -> dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "groupwise_judge_response",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "reasoning": {"type": "string"},
+                    "selected_indices": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": num_responses - 1,
+                        },
+                        "minItems": top_n,
+                        "maxItems": top_n,
+                        "uniqueItems": True,
+                    },
+                },
+                "required": ["reasoning", "selected_indices"],
+            },
+        },
+    }
+
+
+def validate_pointwise_judge_result(result: dict[str, Any]) -> tuple[float, str]:
+    if not isinstance(result.get("reasoning"), str):
+        raise ValueError("pointwise judge response must include string 'reasoning'")
+
+    score = result.get("score")
+    if not isinstance(score, (int, float)):
+        raise ValueError("pointwise judge response must include numeric 'score'")
+
+    score_value = float(score)
+    if score_value < 0.0 or score_value > 10.0:
+        raise ValueError("pointwise judge response 'score' must be between 0 and 10")
+
+    return score_value, result["reasoning"]
+
+
+def validate_groupwise_judge_result(result: dict[str, Any], *, num_responses: int, top_n: int) -> tuple[list[int], str]:
+    if not isinstance(result.get("reasoning"), str):
+        raise ValueError("groupwise judge response must include string 'reasoning'")
+
+    selected_indices = result.get("selected_indices")
+    if not isinstance(selected_indices, list):
+        raise ValueError("groupwise judge response must include list 'selected_indices'")
+
+    if len(selected_indices) != top_n:
+        raise ValueError(f"groupwise judge response 'selected_indices' must contain exactly {top_n} indices")
+
+    if len(set(selected_indices)) != len(selected_indices):
+        raise ValueError("groupwise judge response 'selected_indices' must be unique")
+
+    normalized_indices: list[int] = []
+    for index in selected_indices:
+        if not isinstance(index, int):
+            raise ValueError("groupwise judge response 'selected_indices' must contain integers")
+        if index < 0 or index >= num_responses:
+            raise ValueError("groupwise judge response 'selected_indices' contains out-of-range index")
+        normalized_indices.append(index)
+
+    return normalized_indices, result["reasoning"]
+
+
+def is_response_format_unsupported_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    if "response_format" not in message and "json_schema" not in message:
+        return False
+
+    unsupported_markers = (
+        "not supported",
+        "unsupported",
+        "unknown",
+        "invalid parameter",
+        "extra inputs are not permitted",
+    )
+    return any(marker in message for marker in unsupported_markers)
+
+
 def extract_message_content(message: dict) -> str:
     """
     Extract both content and tool calls from a message
-    
+
     Args:
         message: OpenAI format message dict
-        
+
     Returns:
         Formatted string with content and tool calls
     """
     parts = []
-    
+
     # Add regular content
     if message.get("content"):
         parts.append(message["content"])
-    
+
     # Add tool calls if present
     if message.get("tool_calls"):
         tool_calls_text = []
@@ -115,7 +221,7 @@ def extract_message_content(message: dict) -> str:
             func_args = tool_call["function"]["arguments"]
             tool_calls_text.append(f"Tool call: {func_name}({func_args})")
         parts.append("\n".join(tool_calls_text))
-    
+
     return "\n".join(parts) if parts else ""
 
 
@@ -124,54 +230,59 @@ def with_retry(
     min_wait: float = 0.1,
     max_wait: float = 10.0,
     multiplier: float = 1.0,
-    retry_exceptions: tuple = (Exception,)
+    retry_exceptions: tuple = (Exception,),
 ):
     """
     Decorator to add retry logic to async and sync functions
-    
+
     Args:
         max_attempts: Maximum number of retry attempts
         min_wait: Minimum wait time between retries (seconds)
         max_wait: Maximum wait time between retries (seconds)
         multiplier: Exponential backoff multiplier
         retry_exceptions: Tuple of exception types to retry on
-        
+
     Returns:
         Decorated function with retry logic
     """
+
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         retry_config = retry(
             stop=stop_after_attempt(max_attempts),
             wait=wait_exponential(multiplier=multiplier, min=min_wait, max=max_wait),
             retry=retry_if_exception_type(retry_exceptions),
-            reraise=True
+            reraise=True,
         )
-        
+
         if inspect.iscoroutinefunction(func):
+
             @functools.wraps(func)
             async def async_wrapper(*args, **kwargs):
                 async_retry_func = retry_config(func)
                 return await async_retry_func(*args, **kwargs)
+
             return async_wrapper
         else:
+
             @functools.wraps(func)
             def sync_wrapper(*args, **kwargs):
                 sync_retry_func = retry_config(func)
                 return sync_retry_func(*args, **kwargs)
+
             return sync_wrapper
-    
+
     return decorator
 
 
 async def call_with_retry(fn: Callable[..., T], *args, **kwargs) -> T:
     """
     Wrapper function to add retry logic to any async function call
-    
+
     Args:
         fn: The async function to call with retry
         *args: Positional arguments to pass to the function
         **kwargs: Keyword arguments to pass to the function
-        
+
     Returns:
         Result of the function call
     """
@@ -179,6 +290,6 @@ async def call_with_retry(fn: Callable[..., T], *args, **kwargs) -> T:
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=0.1, max=10),
         retry=retry_if_exception_type(Exception),
-        reraise=True
+        reraise=True,
     )(fn)
     return await retry_fn(*args, **kwargs)

--- a/reward_hub/llm_judge/utils.py
+++ b/reward_hub/llm_judge/utils.py
@@ -133,7 +133,6 @@ def build_groupwise_response_format(*, num_responses: int, top_n: int) -> dict[s
                         },
                         "minItems": top_n,
                         "maxItems": top_n,
-                        "uniqueItems": True,
                     },
                 },
                 "required": ["reasoning", "selected_indices"],

--- a/tests/unit/test_llm_judge_structured_output.py
+++ b/tests/unit/test_llm_judge_structured_output.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Tests for structured output mode in LLM judges."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from reward_hub.llm_judge import create_groupwise_judge, create_pointwise_judge
+
+
+def _mock_completion_response(content: str) -> Mock:
+    return Mock(choices=[Mock(message=Mock(content=content))])
+
+
+class TestPointwiseStructuredOutput:
+    def test_auto_mode_sends_response_format_schema(self):
+        with patch("reward_hub.llm_judge.pointwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+                mock_completion.return_value = _mock_completion_response(
+                    '{"score": 8.5, "reasoning": "clear and correct"}'
+                )
+
+                judge = create_pointwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="overall_quality",
+                    api_key="test-key",
+                    structured_output_mode="auto",
+                )
+
+                conversation = [
+                    {"role": "user", "content": "Test question"},
+                    {"role": "assistant", "content": "Test answer"},
+                ]
+
+                score = judge.score(conversation)
+                assert score == 8.5
+
+                kwargs = mock_completion.call_args.kwargs
+                assert "response_format" in kwargs
+                assert kwargs["response_format"]["type"] == "json_schema"
+
+    def test_auto_mode_falls_back_when_response_format_is_unsupported(self):
+        with patch("reward_hub.llm_judge.pointwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+
+                def side_effect(*args, **kwargs):
+                    if kwargs.get("response_format") is not None:
+                        raise ValueError("response_format not supported")
+                    return _mock_completion_response('{"score": 7.0, "reasoning": "ok"}')
+
+                mock_completion.side_effect = side_effect
+
+                judge = create_pointwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="overall_quality",
+                    api_key="test-key",
+                    structured_output_mode="auto",
+                )
+
+                conversation = [
+                    {"role": "user", "content": "Test question"},
+                    {"role": "assistant", "content": "Test answer"},
+                ]
+
+                score = judge.score(conversation)
+                assert score == 7.0
+                assert mock_completion.call_count == 2
+                assert mock_completion.call_args_list[0].kwargs.get("response_format") is not None
+                assert mock_completion.call_args_list[1].kwargs.get("response_format") is None
+
+    def test_strict_mode_fails_when_response_format_is_unsupported(self):
+        with patch("reward_hub.llm_judge.pointwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+
+                def side_effect(*args, **kwargs):
+                    if kwargs.get("response_format") is not None:
+                        raise ValueError("response_format not supported")
+                    return _mock_completion_response('{"score": 7.0, "reasoning": "ok"}')
+
+                mock_completion.side_effect = side_effect
+
+                judge = create_pointwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="overall_quality",
+                    api_key="test-key",
+                    structured_output_mode="strict",
+                )
+
+                conversation = [
+                    {"role": "user", "content": "Test question"},
+                    {"role": "assistant", "content": "Test answer"},
+                ]
+
+                with pytest.raises(ValueError, match="response_format not supported"):
+                    judge.score(conversation)
+
+
+class TestGroupwiseStructuredOutput:
+    def test_auto_mode_sends_response_format_schema(self):
+        with patch("reward_hub.llm_judge.groupwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+                mock_completion.return_value = _mock_completion_response(
+                    '{"selected_indices": [1], "reasoning": "Response 1 is better"}'
+                )
+
+                judge = create_groupwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="multi_step_tool_judge",
+                    api_key="test-key",
+                    structured_output_mode="auto",
+                )
+
+                conversations = [
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response A"},
+                    ],
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response B"},
+                    ],
+                ]
+
+                scores = judge.score(conversations, top_n=1)
+                assert scores == [0.0, 1.0]
+
+                kwargs = mock_completion.call_args.kwargs
+                assert "response_format" in kwargs
+                assert kwargs["response_format"]["type"] == "json_schema"
+
+    def test_strict_mode_rejects_invalid_groupwise_indices(self):
+        with patch("reward_hub.llm_judge.groupwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+                mock_completion.return_value = _mock_completion_response(
+                    '{"selected_indices": [0, 0], "reasoning": "duplicate indices"}'
+                )
+
+                judge = create_groupwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="multi_step_tool_judge",
+                    api_key="test-key",
+                    structured_output_mode="strict",
+                )
+
+                conversations = [
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response A"},
+                    ],
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response B"},
+                    ],
+                ]
+
+                with pytest.raises(ValueError, match="selected_indices"):
+                    judge.score(conversations, top_n=2)

--- a/tests/unit/test_llm_judge_structured_output.py
+++ b/tests/unit/test_llm_judge_structured_output.py
@@ -155,3 +155,31 @@ class TestGroupwiseStructuredOutput:
 
                 with pytest.raises(ValueError, match="selected_indices"):
                     judge.score(conversations, top_n=2)
+
+    def test_groupwise_schema_avoids_unique_items_keyword(self):
+        with patch("reward_hub.llm_judge.groupwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+                mock_completion.return_value = _mock_completion_response('{"selected_indices": [0], "reasoning": "ok"}')
+
+                judge = create_groupwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="overall_quality",
+                    api_key="test-key",
+                    structured_output_mode="auto",
+                )
+
+                conversations = [
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response A"},
+                    ],
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response B"},
+                    ],
+                ]
+                judge.score(conversations, top_n=1)
+
+                schema = mock_completion.call_args.kwargs["response_format"]["json_schema"]["schema"]
+                selected_indices = schema["properties"]["selected_indices"]
+                assert "uniqueItems" not in selected_indices


### PR DESCRIPTION
## Summary
- Add `structured_output_mode` (`auto`/`strict`/`off`) to pointwise and groupwise LLM judges, defaulting to `auto`.
- Send OpenAI `response_format` JSON schema for judge outputs and validate parsed payloads before converting to scores.
- In `auto` mode, fallback to legacy non-`response_format` calls when providers reject structured-output params; keep `strict` fail-fast behavior.
- Keep provider compatibility by removing `uniqueItems` from groupwise JSON schema and enforcing uniqueness in Python validation.
- Add focused unit tests for schema emission, fallback behavior, strict mode, validation constraints, and the `uniqueItems` regression.

## Test plan
- [x] Added targeted tests for structured-output behavior and validation (`tests/unit/test_llm_judge_structured_output.py`).
- [x] Ran the full reward_hub unit suite (`uv run --extra dev pytest -q`).
- [x] Manual integration sanity-check with `its_hub` Best-of-N + `llm-judge` against local vLLM endpoint (`localhost:8100`) using this branch.


## Unit tests

```bash
uv run --extra dev pytest -q

✓ Unit test mode: Mocking transformers and vllm
============================= test session starts ==============================
platform darwin -- Python 3.10.17, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/rawhad/1_Projects/reward_hub
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.12.1, mock-3.15.1, asyncio-1.3.0
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 64 items / 14 deselected / 50 selected

tests/unit/test_autorm.py ......                                         [ 12%]
tests/unit/test_backends.py .........                                    [ 30%]
tests/unit/test_base.py ........                                         [ 46%]
tests/unit/test_drsow.py ...                                             [ 52%]
tests/unit/test_llm_judge_structured_output.py ......                    [ 64%]
tests/unit/test_retry_mechanism.py ...............                       [ 94%]
tests/unit/test_utils.py ...                                             [100%]

====================== 50 passed, 14 deselected in 25.98s ======================
```
