### PR TITLE
fix: make groupwise schema compatible with vllm grammar

### DIFF
--- a/reward_hub/llm_judge/utils.py
+++ b/reward_hub/llm_judge/utils.py
@@ -133,7 +133,6 @@ def build_groupwise_response_format(*, num_responses: int, top_n: int) -> dict[s
                         },
                         "minItems": top_n,
                         "maxItems": top_n,
-                        "uniqueItems": True,
                     },
                 },
                 "required": ["reasoning", "selected_indices"],

--- a/tests/unit/test_llm_judge_structured_output.py
+++ b/tests/unit/test_llm_judge_structured_output.py
@@ -155,3 +155,31 @@ class TestGroupwiseStructuredOutput:
 
                 with pytest.raises(ValueError, match="selected_indices"):
                     judge.score(conversations, top_n=2)
+
+    def test_groupwise_schema_avoids_unique_items_keyword(self):
+        with patch("reward_hub.llm_judge.groupwise.validate_api_configuration"):
+            with patch("litellm.completion") as mock_completion:
+                mock_completion.return_value = _mock_completion_response('{"selected_indices": [0], "reasoning": "ok"}')
+
+                judge = create_groupwise_judge(
+                    model="gpt-4o-mini",
+                    criterion="overall_quality",
+                    api_key="test-key",
+                    structured_output_mode="auto",
+                )
+
+                conversations = [
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response A"},
+                    ],
+                    [
+                        {"role": "user", "content": "Question"},
+                        {"role": "assistant", "content": "Response B"},
+                    ],
+                ]
+                judge.score(conversations, top_n=1)
+
+                schema = mock_completion.call_args.kwargs["response_format"]["json_schema"]["schema"]
+                selected_indices = schema["properties"]["selected_indices"]
+                assert "uniqueItems" not in selected_indices


### PR DESCRIPTION
## Summary
- Remove `uniqueItems` from the groupwise JSON schema under `response_format` for provider compatibility (notably vLLM grammar constraints).
- Keep uniqueness guarantees by enforcing unique `selected_indices` in Python-side validation.
- Add a regression unit test asserting `uniqueItems` is not emitted in the groupwise schema.

## Notes
- This draft PR is intentionally stacked on #63 so it contains only the compatibility fix commit.
- After #63 merges, retarget this PR to `main`.

## Test plan
- [x] `uv run --extra dev pytest tests/unit/test_llm_judge_structured_output.py -q`