### PR TITLE
Add support for newer versions of vLLM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "transformers>=4.53.2",
     "numpy",
@@ -53,12 +53,12 @@ dev = [
 ]
 # Optionally install vllm for locally hosted reward models
 vllm = [
-    "vllm>=0.10.0"
+    "vllm>=0.14.0"
 ]
 
 # Optionally extend support for Qwen-PRM
 prm = [
-    "vllm>=0.10.0,<=0.12.0",
+    "reward_hub[vllm]",
     "transformers>=4.54,<=4.57.3"
 ]
 

--- a/reward_hub/vllm/reward.py
+++ b/reward_hub/vllm/reward.py
@@ -20,7 +20,6 @@ class VllmProcessRewardModel(AbstractProcessRewardModel):
         print(f"Number of GPUs: {num_gpus}")
         
         self.model = LLM(model=model_name, 
-                    task="reward",
                     gpu_memory_utilization=0.8,
                     tensor_parallel_size=1,
                     )

--- a/tests/e2e/test_vllm_prm.py
+++ b/tests/e2e/test_vllm_prm.py
@@ -103,7 +103,7 @@ class TestVLLMProcessRM:
         assert all(isinstance(score, float) for score in model_agg_scores)
 
     def test_vllm_prm_invalid_model(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(OSError):
             model = VllmProcessRewardModel(
                 model_name="invalid_model",
             )


### PR DESCRIPTION
## Description

- Update vLLM to newer versions i.e. >=0.14.0
- Update Python version to >=3.11
- Remove task from vLLM::LLM args. task was removed from vLLM in 0.13.x
- Fix tests

## Test Results

```
Name: reward_hub
Version: 0.1.10.dev6

Name: its_hub
Version: 0.3.5

Name: vllm
Version: 0.16.0
```

- [x] Unit tests
- [x] tests/e2e/test_hf_orm.py
- [x] tests/e2e/test_hf_prm.py
- [x] tests/e2e/test_vllm_prm.py
- [x] Test with its_hub(0.3.5):

```
from its_hub.utils import SAL_STEP_BY_STEP_SYSTEM_PROMPT
from its_hub.lms import OpenAICompatibleLanguageModel, StepGeneration
from its_hub.algorithms import ParticleFiltering, BestOfN, SelfConsistency, EntropicParticleFiltering
from its_hub.integration.reward_hub import LocalVllmProcessRewardModel
from its_hub.integration.reward_hub import LLMJudgeRewardModel

lm = OpenAICompatibleLanguageModel(
    endpoint="http://localhost:8100/v1",
    api_key="NO_API_KEY",
    model_name="Qwen/Qwen2.5-Math-1.5B-Instruct",
    system_prompt=SAL_STEP_BY_STEP_SYSTEM_PROMPT,
)

sg = StepGeneration(step_token="\n\n", max_steps=32, stop_token=r"\boxed")

prm = LocalVllmProcessRewardModel(
    model_name="Qwen/Qwen2.5-Math-PRM-7B",
    device="cuda:0",
    aggregation_method="prod"
)

scaling_alg = ParticleFiltering(sg, prm)

result = scaling_alg.infer(lm, "Explain quantum entanglement in simple terms", budget=4)

print(result)
```